### PR TITLE
Run training in separate thread

### DIFF
--- a/padatious/intent_container.py
+++ b/padatious/intent_container.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 from os import mkdir
 
 from os.path import isdir
@@ -34,8 +35,7 @@ class IntentContainer(object):
         cache_dir (str): Place to put all saved neural networks
     """
     def __init__(self, cache_dir):
-        if not isdir(cache_dir):
-            mkdir(cache_dir)
+        os.makedirs(cache_dir, exist_ok=True)
         self.must_train = False
         self.intents = IntentManager(cache_dir)
         self.entities = EntityManager(cache_dir)

--- a/padatious/intent_container.py
+++ b/padatious/intent_container.py
@@ -135,6 +135,8 @@ class IntentContainer(object):
                 each time a new intent is trained
             force (bool): Whether to force training if already finished
             single_thread (bool): Whether to force running in a single thread
+        Returns:
+            bool: True if training succeeded without timeout
         """
         if not self.must_train and not force:
             return
@@ -146,6 +148,7 @@ class IntentContainer(object):
         self.train_thread.join(timeout)
 
         self.must_train = False
+        return not self.train_thread.is_alive()
 
     def calc_intents(self, query):
         """

--- a/padatious/intent_container.py
+++ b/padatious/intent_container.py
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-from os import mkdir
-
-from os.path import isdir
-from time import sleep
 
 import padaos
 from threading import Thread

--- a/padatious/intent_container.py
+++ b/padatious/intent_container.py
@@ -124,7 +124,7 @@ class IntentContainer(object):
         t2.join()
         self.entities.calc_ent_dict()
 
-    def train(self, *args, **kwargs):
+    def train(self, *args, force=False, **kwargs):
         """
         Trains all the loaded intents that need to be updated
         If a cache file exists with the same hash as the intent file,
@@ -133,8 +133,11 @@ class IntentContainer(object):
         Args:
             print_updates (bool): Whether to print a message to stdout
                 each time a new intent is trained
+            force (bool): Whether to force training if already finished
             single_thread (bool): Whether to force running in a single thread
         """
+        if not self.must_train and not force:
+            return
         self.padaos.compile()
 
         timeout = kwargs.setdefault('timeout', 20)
@@ -157,7 +160,7 @@ class IntentContainer(object):
         """
         if self.must_train:
             self.train()
-        intents = {} if self.train_thread.is_alive() else {
+        intents = {} if self.train_thread and self.train_thread.is_alive() else {
             i.name: i for i in self.intents.calc_intents(query, self.entities)
         }
         sent = tokenize(query)

--- a/padatious/training_manager.py
+++ b/padatious/training_manager.py
@@ -14,7 +14,6 @@
 import multiprocessing as mp
 from functools import partial
 from multiprocessing.context import TimeoutError
-from os import mkdir
 from os.path import join, isfile, isdir, splitext
 
 import padatious

--- a/padatious/training_manager.py
+++ b/padatious/training_manager.py
@@ -70,9 +70,6 @@ class TrainingManager(object):
         self.train_data.remove_lines(name)
 
     def train(self, debug=True, single_thread=False, timeout=20):
-        if not isdir(self.cache):
-            mkdir(self.cache)
-
         train = partial(
             _train_and_save, cache=self.cache, data=self.train_data, print_updates=debug
         )

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from time import monotonic
 
+import pytest
+import random
 from os import mkdir
 from os.path import isdir, join
 from shutil import rmtree
@@ -54,6 +57,27 @@ class TestIntentContainer:
 
         test(False, False)
         test(True, True)
+
+    def _create_large_intent(self, depth):
+        if depth == 0:
+            return '(a|b|)'
+        return '{0} {0}'.format(self._create_large_intent(depth - 1))
+
+    @pytest.mark.skip(reason="Takes a long time")
+    def test_train_timeout(self):
+        self.cont.add_intent('a', [
+            ' '.join(random.choice('abcdefghijklmnopqrstuvwxyz') for _ in range(5))
+            for __ in range(300)
+        ])
+        self.cont.add_intent('b', [
+            ' '.join(random.choice('abcdefghijklmnopqrstuvwxyz') for _ in range(5))
+            for __ in range(300)
+
+        ])
+        a = monotonic()
+        self.cont.train(True, timeout=1)
+        b = monotonic()
+        assert b - a <= 2
 
     def test_calc_intents(self):
         self.test_add_intent()

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -64,7 +64,7 @@ class TestIntentContainer:
             return '(a|b|)'
         return '{0} {0}'.format(self._create_large_intent(depth - 1))
 
-    @pytest.mark.skip(reason="Takes a long time")
+    @pytest.mark.skipif(not os.environ.get('RUN_LONG'), reason="Takes a long time")
     def test_train_timeout(self):
         self.cont.add_intent('a', [
             ' '.join(random.choice('abcdefghijklmnopqrstuvwxyz') for _ in range(5))

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from time import monotonic
 
+import os
 import pytest
 import random
 from os import mkdir
@@ -78,6 +79,11 @@ class TestIntentContainer:
         self.cont.train(True, timeout=1)
         b = monotonic()
         assert b - a <= 2
+
+        a = monotonic()
+        self.cont.train(True, timeout=1)
+        b = monotonic()
+        assert b - a <= 0.1
 
     def test_calc_intents(self):
         self.test_add_intent()


### PR DESCRIPTION
This runs training in a separate thread so that it can be aborted if it takes too long. Ideally, this would terminate the training, but this doesn't work properly for some reason despite using timeouts in the multiprocessing threadpool.