### PR TITLE
Add automated testing

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,48 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on:
+  push:
+    branches: [ dev ]
+  pull_request:
+    branches: [ dev ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install FANN2 from source
+      run: |
+        wget http://downloads.sourceforge.net/project/fann/fann/2.2.0/FANN-2.2.0-Source.zip
+        unzip FANN-2.2.0-Source.zip
+        pushd FANN-2.2.0-Source/
+        cmake .
+        sudo make install
+        popd
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest
+        python setup.py install
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        # Ensure pytest can find the FANN2 libraries
+        LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH python -m pytest


### PR DESCRIPTION
Add automated testing via Github Actions

This PR adds testing on current stable versions of Python 3.6 - 3.9. 

The setup.py suggests that much older versions may also work however the tests weren't passing. Given those versions of Python have reached EOL and Mycroft no longer supports them, the have been left off and should probably be removed from the PyPI meta data unless someone else would like to get the tests working for them.

#### Type of PR
- [ ] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [x] Test improvements

#### Testing
Automated tests should pass