### PR TITLE
Add missing system packages for command line usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Padatious requires the following native packages to be installed:
 Ubuntu:
 
 ```
-sudo apt-get install libfann-dev python3-dev python3-pip swig
+sudo apt-get install libfann-dev python3-dev python3-pip swig libfann-dev python3-fann2
 ```
 
 Next, install Padatious via `pip3`:


### PR DESCRIPTION
Previously, Padatious would fail to install using pypi, citing that fann could not be found. By installing the development library, and the fann2 bindings, it will now install Padatious with no issue

#### Description
Fixes issue #21

#### Type of PR
- [ ] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [X] Documentation improvements
- [ ] Test improvements
